### PR TITLE
feat: Add Deslicer logo to README homepage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
-# DEV1666 - AI Sidekick for Splunk Lab Exercises
+<div align="center">
+  <img src="./media/deslicer_white.svg" alt="Deslicer" width="200"/>
+</div>
 
+# DEV1666 - AI Sidekick for Splunk Lab Exercises
 
 ## Table of Contents
 


### PR DESCRIPTION
- Added deslicer_white.svg logo above the main title
- Centered logo for professional branding
- Logo appears as first element for immediate brand recognition